### PR TITLE
ByteArrayToImageSourceConverterPage

### DIFF
--- a/src/Features/Gallery/Pages/Toolkit/Converters/ByteArrayToImageSourceConverter/ByteArrayToImageSourceConverterControlInfo.cs
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ByteArrayToImageSourceConverter/ByteArrayToImageSourceConverterControlInfo.cs
@@ -1,0 +1,24 @@
+﻿namespace MAUIsland;
+
+class ByteArrayToImageSourceConverterControlInfo : ICommunityToolkitGalleryCardInfo
+{
+    public string ControlName => "Byte Array To Image Source Converter";
+
+    public string ControlRoute => typeof(ByteArrayToImageSourceConverterPage).FullName;
+    public ImageSource ControlIcon => new FontImageSource()
+    {
+        FontFamily = FontNames.FluentSystemIconsRegular,
+        Size = 100,
+        Glyph = FluentUIIcon.Ic_fluent_approvals_app_20_regular
+    };
+    public string ControlDetail => "The ByteArrayToImageSourceConverter is a converter that allows the user to convert an incoming value from a byte array and returns an ImageSource. This object can then be used as the Source of an Image control.";
+    public string GitHubUrl => $"https://github.com/Strypper/mauisland/tree/main/src/Features/Gallery/Pages/Toolkit/{ControlName}";
+    public string DocumentUrl => $"https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/converters/byte-array-to-image-source-converter";
+    public string GroupName => ControlGroupInfo.CommunityToolkit;
+    public GalleryCardType CardType => GalleryCardType.Converter;
+    public GalleryCardStatus CardStatus => throw new NotImplementedException();
+    public DateTime LastUpdate => throw new NotImplementedException();
+    public List<string> DoList => throw new NotImplementedException();
+
+    public List<string> DontList => throw new NotImplementedException();
+}

--- a/src/Features/Gallery/Pages/Toolkit/Converters/ByteArrayToImageSourceConverter/ByteArrayToImageSourceConverterPage.xaml
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ByteArrayToImageSourceConverter/ByteArrayToImageSourceConverterPage.xaml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<app:BasePage 
+    x:Class="MAUIsland.ByteArrayToImageSourceConverterPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:app="clr-namespace:MAUIsland"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    Title="Byte Array To Image Source Converter"
+    Padding="10"
+    x:DataType="app:ByteArrayToImageSourceConverterPageViewModel">
+
+    <app:BasePage.ToolbarItems>
+        <ToolbarItem
+            Command="{x:Binding OpenUrlCommand}"
+            CommandParameter="{x:Binding ControlInformation.GitHubUrl}"
+            IconImageSource="githublogo.png"
+            Text="Source code" />
+        <ToolbarItem
+            Command="{x:Binding OpenUrlCommand}"
+            CommandParameter="{x:Binding ControlInformation.DocumentUrl}"
+            IconImageSource="microsoft.png"
+            Text="Original Document" />
+    </app:BasePage.ToolbarItems>
+
+    <app:BasePage.Resources>
+        <x:Array x:Key="PropertiesItemsSource" Type="{x:Type x:String}">
+            <x:String>
+                <![CDATA[   <strong style="color:blue">DefaultConvertReturnValue</strong> is type of <strong style="color:blue">object?</strong> default value to return when <strong style="color:blue">IValueConverter.Convert(object?, Type, object?, CultureInfo?)</strong> throws an <strong style="color:blue">Exception</strong>. This value is used when <strong style="color:blue">CommunityToolkit.Maui.Options.ShouldSuppressExceptionsInConverters</strong> is set to true.   ]]>
+            </x:String>
+            <x:String>
+                <![CDATA[   <strong style="color:blue">DefaultConvertBackReturnValue</strong> is type of <strong style="color:blue">object?</strong> default value to return when <strong style="color:blue">IValueConverter.ConvertBack(object?, Type, object?, CultureInfo?)</strong> throws an <strong style="color:blue">Exception</strong>. This value is used when <strong style="color:blue">CommunityToolkit.Maui.Options.ShouldSuppressExceptionsInConverters</strong> is set to true.  ]]>
+            </x:String>
+        </x:Array>
+
+        <toolkit:ByteArrayToImageSourceConverter  x:Key="ByteArrayToImageSourceConverter"/>
+    </app:BasePage.Resources>
+
+    <ScrollView>
+        <VerticalStackLayout Spacing="20">
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <Label Text="{x:Binding ControlInformation.ControlDetail}" />
+            </Frame>
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Style="{x:StaticResource DocumentSectionTitleStyle}" Text="Converter Properties" />
+                    <CollectionView ItemsSource="{x:StaticResource PropertiesItemsSource}" 
+                                    Style="{x:StaticResource PropertiesListStyle}"/>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Style="{x:StaticResource DocumentSectionTitleStyle}" Text="Setup MediaElement" />
+                    <VerticalStackLayout>
+                        <Label Text="{x:Binding SetupDescription}"/>
+                        <Label Text="{x:Binding XamlNamespace}" TextColor="Blue"/>
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Therefore the following:"/>
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding FullNamepaceExampleBefore}" />
+                    <Label Text="Would be modified to include the xmlns as follows:"/>
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding FullNamepaceExampleAfter}" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Style="{x:StaticResource DocumentSectionTitleStyle}" Text="Bool To Object Converter" />
+                    <HorizontalStackLayout HeightRequest="200" 
+                                            Spacing="10">
+                        <Label VerticalOptions="Center">
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="The converter will turn the "/>
+                                    <Span Text="byte[] "
+                                          FontAttributes="Bold"/>
+                                    <Span Text=" property into a ImageSource like this"/>
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+                        <Image Source="{x:Binding ImageByteArray, Converter={x:StaticResource ByteArrayToImageSourceConverter}}"/>
+                    </HorizontalStackLayout>
+                    <Label VerticalOptions="Center">
+                        <Label.FormattedText>
+                            <FormattedString>
+                                <Span Text="Without the converter "/>
+                                <Span Text="byte[]"
+                                        FontAttributes="Bold"/>
+                                <Span Text=" value will look like this"/>
+                            </FormattedString>
+                        </Label.FormattedText>
+                    </Label>
+                    <Label Text="{x:Binding ImageByteArrayToString}" 
+                           LineBreakMode="TailTruncation"/>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="This is ViewModel code" />
+                    <app:SourceCodeExpander CodeType="CSharp" Code="{x:Binding CSharpxamlConverterTestingViewModel}" />
+                    <Label Text="Here what your converter look like" />
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding XamlConverterSetup}" />
+                    <Label Text="This Xaml code" />
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding XamlConverterTesting}" />
+                </VerticalStackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </ScrollView>
+
+</app:BasePage>

--- a/src/Features/Gallery/Pages/Toolkit/Converters/ByteArrayToImageSourceConverter/ByteArrayToImageSourceConverterPage.xaml.cs
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ByteArrayToImageSourceConverter/ByteArrayToImageSourceConverterPage.xaml.cs
@@ -1,0 +1,11 @@
+namespace MAUIsland;
+
+public partial class ByteArrayToImageSourceConverterPage : IGalleryPage
+{
+	public ByteArrayToImageSourceConverterPage(ByteArrayToImageSourceConverterPageViewModel vm)
+	{
+		InitializeComponent();
+
+		BindingContext = vm;
+	}
+}

--- a/src/Features/Gallery/Pages/Toolkit/Converters/ByteArrayToImageSourceConverter/ByteArrayToImageSourceConverterPageViewModel.cs
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ByteArrayToImageSourceConverter/ByteArrayToImageSourceConverterPageViewModel.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.Maui.Controls;
+using System.Reflection;
+
+namespace MAUIsland;
+
+public partial class ByteArrayToImageSourceConverterPageViewModel : NavigationAwareBaseViewModel
+{
+    #region [Services]
+    #endregion
+
+    #region [ CTor ]
+    public ByteArrayToImageSourceConverterPageViewModel(IAppNavigator appNavigator)
+        : base(appNavigator)
+    { } 
+    #endregion
+
+    #region [ Properties ]
+    [ObservableProperty]
+    IGalleryCardInfo controlInformation;
+
+    [ObservableProperty]
+    ObservableCollection<MrIncreadible> mrIncreadibles;
+
+    [ObservableProperty]
+    ObservableCollection<IGalleryCardInfo> controlGroupList;
+
+    [ObservableProperty]
+    byte[] imageByteArray;
+
+    [ObservableProperty]
+    string imageByteArrayToString;
+
+    [ObservableProperty]
+    string setupDescription =
+    "In order to use the toolkit in XAML the following xmlns needs to be added into your page or view:";
+
+    [ObservableProperty]
+    string xamlNamespace =
+        "xmlns:toolkit=\"http://schemas.microsoft.com/dotnet/2022/maui/toolkit\"";
+
+    [ObservableProperty]
+    string fullNamepaceExampleBefore =
+        "<ContentPage\r\n" +
+        "    x:Class=\"MAUIsland.MediaElementPage\"\r\n" +
+        "    xmlns=\"http://schemas.microsoft.com/dotnet/2021/maui\"\r\n" +
+        "    xmlns:x=\"http://schemas.microsoft.com/winfx/2009/xaml\"\r\n" +
+        "</ContentPage>";
+
+    [ObservableProperty]
+    string fullNamepaceExampleAfter =
+        "<ContentPage\r\n" +
+        "    x:Class=\"MAUIsland.MediaElementPage\"\r\n" +
+        "    xmlns=\"http://schemas.microsoft.com/dotnet/2021/maui\"\r\n" +
+        "    xmlns:x=\"http://schemas.microsoft.com/winfx/2009/xaml\"\r\n" +
+        "    xmlns:toolkit=\"http://schemas.microsoft.com/dotnet/2022/maui/toolkit\">\r\n" +
+        "</ContentPage>";
+
+    [ObservableProperty]
+    string xamlConverterTesting =
+        "<Image Source=\"{x:Binding ImageByteArray, Converter={x:StaticResource ByteArrayToImageSourceConverter}}\"/>";
+
+    [ObservableProperty]
+    string xamlConverterSetup =
+        "<ContentPage>\r\n" +
+        "   <ContentPage.Resources>\r\n" +
+        "        <toolkit:ByteArrayToImageSourceConverter x:Key=\"ByteArrayToImageSourceConverter\"/>\r\n" +
+        "   </ContentPage.Resources>\r\n" +
+        "</ContentPage>";
+
+    [ObservableProperty]
+    string cSharpxamlConverterTestingViewModel =
+        "[ObservableProperty]\r\n" +
+        "byte[] imageByteArray;";
+    #endregion
+
+    #region[ Relay Command ]
+    [RelayCommand]
+    Task OpenUrlAsync(string url)
+        => AppNavigator.OpenUrlAsync(url);
+    #endregion
+
+    #region [ Overrides ]
+    protected override void OnInit(IDictionary<string, object> query)
+    {
+        base.OnInit(query);
+        ControlInformation = query.GetData<IGalleryCardInfo>();
+        LoadDataAsync().FireAndForget();
+    }
+    #endregion
+
+    #region [ Data ]
+    private async Task LoadDataAsync()
+    {
+        ImageByteArray = await ImageUrlToByteArrayAsync("https://aka.ms/campus.jpg");
+        ImageByteArrayToString = ByteArrayToString(ImageByteArray);
+    }
+    #endregion
+
+    #region [ Method ]
+    public async Task<byte[]> ImageUrlToByteArrayAsync(string imageUrl)
+    {
+        using var httpClient = new HttpClient();
+        return await httpClient.GetByteArrayAsync(imageUrl).ConfigureAwait(false);
+    }
+    public string ByteArrayToString(byte[] byteArray)
+    {
+        return BitConverter.ToString(byteArray);
+    }
+    #endregion
+}

--- a/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterControlInfo.cs
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterControlInfo.cs
@@ -1,0 +1,24 @@
+﻿namespace MAUIsland;
+
+class ColorToBlackOrWhiteConverterControlInfo : ICommunityToolkitGalleryCardInfo
+{
+    public string ControlName => "Color To Black Or White Converter";
+
+    public string ControlRoute => typeof(ColorToBlackOrWhiteConverterPage).FullName;
+    public ImageSource ControlIcon => new FontImageSource()
+    {
+        FontFamily = FontNames.FluentSystemIconsRegular,
+        Size = 100,
+        Glyph = FluentUIIcon.Ic_fluent_approvals_app_20_regular
+    };
+    public string ControlDetail => "The ColorToBlackOrWhiteConverter is a one way converter that allows users to convert an incoming Color to a monochrome value of either Colors.Black or Colors.White.";
+    public string GitHubUrl => $"https://github.com/Strypper/mauisland/tree/main/src/Features/Gallery/Pages/Toolkit/{ControlName}";
+    public string DocumentUrl => $"https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/converters/color-to-black-or-white-converter";
+    public string GroupName => ControlGroupInfo.CommunityToolkit;
+    public GalleryCardType CardType => GalleryCardType.Converter;
+    public GalleryCardStatus CardStatus => throw new NotImplementedException();
+    public DateTime LastUpdate => throw new NotImplementedException();
+    public List<string> DoList => throw new NotImplementedException();
+
+    public List<string> DontList => throw new NotImplementedException();
+}

--- a/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterPage.xaml
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterPage.xaml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<app:BasePage 
+    x:Class="MAUIsland.ColorToBlackOrWhiteConverterPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:app="clr-namespace:MAUIsland"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    Title="Byte Array To Image Source Converter"
+    Padding="10"
+    x:DataType="app:ColorToBlackOrWhiteConverterPageViewModel">
+
+    <app:BasePage.ToolbarItems>
+        <ToolbarItem
+            Command="{x:Binding OpenUrlCommand}"
+            CommandParameter="{x:Binding ControlInformation.GitHubUrl}"
+            IconImageSource="githublogo.png"
+            Text="Source code" />
+        <ToolbarItem
+            Command="{x:Binding OpenUrlCommand}"
+            CommandParameter="{x:Binding ControlInformation.DocumentUrl}"
+            IconImageSource="microsoft.png"
+            Text="Original Document" />
+    </app:BasePage.ToolbarItems>
+
+    <app:BasePage.Resources>
+        <x:Array x:Key="PropertiesItemsSource" Type="{x:Type x:String}">
+            <x:String>
+                <![CDATA[   <strong style="color:blue">DefaultConvertReturnValue</strong> is type of <strong style="color:blue">object?</strong> default value to return when <strong style="color:blue">IValueConverter.Convert(object?, Type, object?, CultureInfo?)</strong> throws an <strong style="color:blue">Exception</strong>. This value is used when <strong style="color:blue">CommunityToolkit.Maui.Options.ShouldSuppressExceptionsInConverters</strong> is set to true.   ]]>
+            </x:String>
+            <x:String>
+                <![CDATA[   <strong style="color:blue">DefaultConvertBackReturnValue</strong> is type of <strong style="color:blue">object?</strong> default value to return when <strong style="color:blue">IValueConverter.ConvertBack(object?, Type, object?, CultureInfo?)</strong> throws an <strong style="color:blue">Exception</strong>. This value is used when <strong style="color:blue">CommunityToolkit.Maui.Options.ShouldSuppressExceptionsInConverters</strong> is set to true.  ]]>
+            </x:String>
+        </x:Array>
+
+        <toolkit:ColorToBlackOrWhiteConverter x:Key="ColorToBlackOrWhiteConverter" />
+    </app:BasePage.Resources>
+
+    <ScrollView>
+        <VerticalStackLayout Spacing="20">
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <Label Text="{x:Binding ControlInformation.ControlDetail}" />
+            </Frame>
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Style="{x:StaticResource DocumentSectionTitleStyle}" Text="Converter Properties" />
+                    <CollectionView ItemsSource="{x:StaticResource PropertiesItemsSource}" 
+                                    Style="{x:StaticResource PropertiesListStyle}"/>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Style="{x:StaticResource DocumentSectionTitleStyle}" Text="Setup MediaElement" />
+                    <VerticalStackLayout>
+                        <Label Text="{x:Binding SetupDescription}"/>
+                        <Label Text="{x:Binding XamlNamespace}" TextColor="Blue"/>
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Therefore the following:"/>
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding FullNamepaceExampleBefore}" />
+                    <Label Text="Would be modified to include the xmlns as follows:"/>
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding FullNamepaceExampleAfter}" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Style="{x:StaticResource DocumentSectionTitleStyle}" Text="Bool To Object Converter" />
+                    <Label VerticalOptions="Center">
+                        <Label.FormattedText>
+                            <FormattedString>
+                                <Span Text="The converter will turn this text color "/>
+                                <Span Text="The Text is showing in monochrome"
+                                      TextColor="{x:Binding TextColor}"
+                                      FontAttributes="Bold"/>
+                                <Span Text=" into this text color "/>
+                                <Span Text="The Text is showing in monochrome"
+                                      TextColor="{x:Binding TextColor, Converter={x:StaticResource ColorToBlackOrWhiteConverter}}"
+                                      FontAttributes="Bold"
+                                      BackgroundColor="Gray"/>
+                            </FormattedString>
+                        </Label.FormattedText>
+                    </Label>
+                    <Label Text="It worked on FontImageSource too"/>
+                    <HorizontalStackLayout Spacing="5">
+                        <Label Text="The converter will turn this Icon color"/>
+                        <Image HeightRequest="40" WidthRequest="40" BackgroundColor="Gray">
+                            <Image.Source>
+                                <FontImageSource Glyph="{x:Static app:FluentUIIcon.Ic_fluent_person_circle_24_regular}" 
+                                                 Color="{x:Binding IconColor}"/>
+                            </Image.Source>
+                        </Image>
+                        <Label Text=" into this color "/>
+                        <Image HeightRequest="40" WidthRequest="40" BackgroundColor="Gray">
+                            <Image.Source>
+                                <FontImageSource Glyph="{x:Static app:FluentUIIcon.Ic_fluent_person_circle_24_regular}" 
+                                                 Color="{x:Binding IconColor, Converter={x:StaticResource ColorToBlackOrWhiteConverter}}"/>
+                            </Image.Source>
+                        </Image>
+                    </HorizontalStackLayout>
+                    <Label Text="It work for all of color setting" TextColor="OrangeRed"/>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="This is ViewModel code" />
+                    <app:SourceCodeExpander CodeType="CSharp" Code="{x:Binding CSharpxamlConverterTestingViewModel}" />
+                    <Label Text="Here what your converter look like" />
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding XamlConverterSetup}" />
+                    <Label Text="This Xaml TextColor code" />
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding XamlConverterTextTesting}" />
+                    <Label Text="This Xaml FontImageSource.Color code" />
+                    <app:SourceCodeExpander CodeType="Xaml" Code="{x:Binding XamlConverterIconTesting}" />
+                </VerticalStackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </ScrollView>
+
+</app:BasePage>

--- a/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterPage.xaml
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterPage.xaml
@@ -69,16 +69,16 @@
 
             <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
                 <VerticalStackLayout Spacing="10">
-                    <Label Style="{x:StaticResource DocumentSectionTitleStyle}" Text="Bool To Object Converter" />
+                    <Label Style="{x:StaticResource DocumentSectionTitleStyle}" Text="Color To Black Or White Converter" />
                     <Label VerticalOptions="Center">
                         <Label.FormattedText>
                             <FormattedString>
                                 <Span Text="The converter will turn this text color "/>
-                                <Span Text="The Text is showing in monochrome"
+                                <Span Text="Text Color"
                                       TextColor="{x:Binding TextColor}"
                                       FontAttributes="Bold"/>
                                 <Span Text=" into this text color "/>
-                                <Span Text="The Text is showing in monochrome"
+                                <Span Text="Text Color"
                                       TextColor="{x:Binding TextColor, Converter={x:StaticResource ColorToBlackOrWhiteConverter}}"
                                       FontAttributes="Bold"
                                       BackgroundColor="Gray"/>

--- a/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterPage.xaml.cs
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterPage.xaml.cs
@@ -1,0 +1,11 @@
+namespace MAUIsland;
+
+public partial class ColorToBlackOrWhiteConverterPage : IGalleryPage
+{
+	public ColorToBlackOrWhiteConverterPage(ColorToBlackOrWhiteConverterPageViewModel vm)
+	{
+		InitializeComponent();
+
+		BindingContext = vm;
+	}
+}

--- a/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterPageViewModel.cs
+++ b/src/Features/Gallery/Pages/Toolkit/Converters/ColorToBlackOrWhiteConverter/ColorToBlackOrWhiteConverterPageViewModel.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.Maui.Controls;
+using System.Reflection;
+
+namespace MAUIsland;
+
+public partial class ColorToBlackOrWhiteConverterPageViewModel : NavigationAwareBaseViewModel
+{
+    #region [Services]
+    #endregion
+
+    #region [ CTor ]
+    public ColorToBlackOrWhiteConverterPageViewModel(IAppNavigator appNavigator)
+        : base(appNavigator)
+    { } 
+    #endregion
+
+    #region [ Properties ]
+    [ObservableProperty]
+    IGalleryCardInfo controlInformation;
+
+    [ObservableProperty]
+    ObservableCollection<IGalleryCardInfo> controlGroupList;
+
+    [ObservableProperty]
+    Color textColor = Colors.BlueViolet;
+
+    [ObservableProperty]
+    Color iconColor = Colors.Brown;
+
+    [ObservableProperty]
+    string setupDescription =
+    "In order to use the toolkit in XAML the following xmlns needs to be added into your page or view:";
+
+    [ObservableProperty]
+    string xamlNamespace =
+        "xmlns:toolkit=\"http://schemas.microsoft.com/dotnet/2022/maui/toolkit\"";
+
+    [ObservableProperty]
+    string fullNamepaceExampleBefore =
+        "<ContentPage\r\n" +
+        "    x:Class=\"MAUIsland.MediaElementPage\"\r\n" +
+        "    xmlns=\"http://schemas.microsoft.com/dotnet/2021/maui\"\r\n" +
+        "    xmlns:x=\"http://schemas.microsoft.com/winfx/2009/xaml\"\r\n" +
+        "</ContentPage>";
+
+    [ObservableProperty]
+    string fullNamepaceExampleAfter =
+        "<ContentPage\r\n" +
+        "    x:Class=\"MAUIsland.MediaElementPage\"\r\n" +
+        "    xmlns=\"http://schemas.microsoft.com/dotnet/2021/maui\"\r\n" +
+        "    xmlns:x=\"http://schemas.microsoft.com/winfx/2009/xaml\"\r\n" +
+        "    xmlns:toolkit=\"http://schemas.microsoft.com/dotnet/2022/maui/toolkit\">\r\n" +
+        "</ContentPage>";
+
+    [ObservableProperty]
+    string xamlConverterTextTesting =
+        "<Label Text=\"The Text is showing in monochrome\"\r\n" +
+        "       TextColor=\"{x:Binding TextColor, Converter={x:StaticResource ColorToBlackOrWhiteConverter}}\"\r\n" +
+        "       FontAttributes=\"Bold\"\r\n" +
+        "       BackgroundColor=\"Gray\"/>";
+
+    [ObservableProperty]
+    string xamlConverterIconTesting =
+        "<Image HeightRequest=\"40\" WidthRequest=\"40\" BackgroundColor=\"Gray\">\r\n" +
+        "   <Image.Source>\r\n" +
+        "       <FontImageSource Glyph=\"{x:Static app:FluentUIIcon.Ic_fluent_person_circle_24_regular}\" \r\n" +
+        "                        Color=\"{x:Binding IconColor, Converter={x:StaticResource ColorToBlackOrWhiteConverter}}\"/>\r\n" +
+        "   </Image.Source>\r\n" +
+        "</Image>";
+
+    [ObservableProperty]
+    string xamlConverterSetup =
+        "<ContentPage>\r\n" +
+        "   <ContentPage.Resources>\r\n" +
+        "        <toolkit:ColorToBlackOrWhiteConverter x:Key=\"ColorToBlackOrWhiteConverter\" />\r\n" +
+        "   </ContentPage.Resources>\r\n" +
+        "</ContentPage>";
+
+    [ObservableProperty]
+    string cSharpxamlConverterTestingViewModel =
+        "[ObservableProperty]\r\n" +
+        "Color textColor = Colors.BlueViolet;\r\n\r\n" +
+        "[ObservableProperty]\r\n" +
+        "Color iconColor = Colors.Brown;";
+    #endregion
+
+    #region[ Relay Command ]
+    [RelayCommand]
+    Task OpenUrlAsync(string url)
+        => AppNavigator.OpenUrlAsync(url);
+    #endregion
+
+    #region [ Overrides ]
+    protected override void OnInit(IDictionary<string, object> query)
+    {
+        base.OnInit(query);
+        ControlInformation = query.GetData<IGalleryCardInfo>();
+        LoadDataAsync().FireAndForget();
+    }
+    #endregion
+
+    #region [ Data ]
+    private async Task LoadDataAsync()
+    {
+    }
+    #endregion
+
+    #region [ Method ]
+    #endregion
+}


### PR DESCRIPTION
# COOL NEW PAGE !!!!
### Page name: Byte Array To Image Source Converter Page
  
## Contributors

[//]: contributor-faces

<a href="https://github.com/E-vaTRON"><img src="https://totechsintranet.blob.core.windows.net/team-members/Long.jpg" title="E-vaTRON" width="80" height="80"></a>

[//]: contributor-faces
  
## Describe your changes

## Have we discussed about this before ? (Please link the discussion link below)

## Added AdaptiveProperties page requirements as following:
- [x] AdaptivePropertiesPage.xaml
  - [x] Change the `x:Class` to project namespace standard (ex: `x:Class="MAUIsland.LabelPage"`)?
  - [x] Include `xmlns:app="clr-namespace:MAUIsland"`
  - [x] Change `ContentPage` to `app:BasePage`
  - [x] Hook the `x:DataType` to the AdaptivePropertiesViewModel
  - [x] Provide `Padding="10"` to `app:BasePage`
  - [x] Provide `ControlInfo` to `app:BasePage.Resources`
  - [x] Provide `PropertiesListHeader` to `app:BasePage.Resources`
  - [x] Provide `PropertiesListFooter` to `app:BasePage.Resources`
  - [x] Provide `PropertyItemsSource` to `app:BasePage.Resources`
  - [x] Provide a brief `Control Info` UI ?
    ```xml
       <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
                <Label Text="{x:StaticResource ControlInfo}" />
       </Frame>
    ```
    - [x] Provide `Properties List` UI
    ```xml
       <Frame Style="{x:StaticResource DocumentContentFrameStyle}">
                <CollectionView
                    Footer="{x:StaticResource PropertiesListFooter}"
                    Header="{x:StaticResource PropertiesListHeader}"
                    ItemsSource="{x:StaticResource PropertyItemsSource}"
                    Style="{x:StaticResource PropertiesListStyle}" />
       </Frame>
    ```
- [x] AdaptivePropertiesPage.xaml.cs
  - [x] Did you change the `namespace` to project namespace standard `namespace MAUIsland`?
  - [x] Did you remove inheritance `ContentPage`?
  - [x] Did you organize everything inside `region`?
  - [x] Did you change `<Page>ViewModel` into the constructor parmeter?
  - [x] Did you hook the page binding context to the page view model - `BindingContext = vm;` ?
- [x] AdaptivePropertiesPageViewModel.cs
  - [x] Did you inherit the `NavigationAwareBaseViewModel`?
  - [x] Did you organize everything inside `region`?
  - [x] Did you modify the constructor like the example we provide?
    ```cs
    #region [CTor]
    public LabelPageViewModel(IAppNavigator appNavigator)
                                    : base(appNavigator)
    {

    }
    #endregion
    ```

## Register AdaptiveProperties page route requirements as following:
- [x] Did you create now route constant ?
- [x] Did you register page route in AppShell.xaml.cs ?
- [x] If the page is one of applciation root route did you register it to AppShell.xaml ?
  
## Register AdaptiveProperties page services: 
- [x] Did you register the page with the view model in `RegisterPages` ?
- [x] Did you register all the created services `RegisterServices` ? 
